### PR TITLE
issue #1 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build
 /_javabridge.c
 *.pyc
+*.pyd
 /javabridge/_javabridge.so
 /python_javabridge.egg-info
 /docs/_build

--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -22,7 +22,6 @@ import re
 import subprocess
 import sys
 import uuid
-import _javabridge
 from .locate import find_javahome
 
 logger = logging.getLogger(__name__)
@@ -79,6 +78,7 @@ def _find_jvm():
 
     if jvm_dir is None:
         raise JVMNotFoundError()
+    return jvm_dir
 
 class JavaError(ValueError):
     '''An error caused by using the Javabridge incorrectly'''
@@ -115,6 +115,10 @@ class JavaException(Exception):
         finally:
             env.exception_clear()
 
+if sys.platform == "win32":
+    # Need to fix up executable path to pick up jvm.dll
+    os.environ["PATH"] = os.environ["PATH"] + os.pathsep + _find_jvm()
+import _javabridge
 __vm = None
 __wake_event = threading.Event()
 __dead_event = threading.Event()

--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -66,13 +66,45 @@ def find_jdk():
         return "Doesn't matter"
     if is_win:
         import _winreg
-        jdk_key_path = 'SOFTWARE\\JavaSoft\\Java Development Kit'
-        kjdk = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, jdk_key_path)
-        kjdk_values = dict([_winreg.EnumValue(kjdk, i)[:2]
-                             for i in range(_winreg.QueryInfoKey(kjdk)[1])])
-        current_version = kjdk_values['CurrentVersion']
-        kjdk_current = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
-                                       jdk_key_path + '\\' + current_version)
-        kjdk_current_values = dict([_winreg.EnumValue(kjdk_current, i)[:2]
-                                    for i in range(_winreg.QueryInfoKey(kjdk_current)[1])])
-        return kjdk_current_values['JavaHome']
+        import exceptions
+        try:
+            jdk_key_path = 'SOFTWARE\\JavaSoft\\Java Development Kit'
+            kjdk = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, jdk_key_path)
+            kjdk_values = dict([_winreg.EnumValue(kjdk, i)[:2]
+                                 for i in range(_winreg.QueryInfoKey(kjdk)[1])])
+            current_version = kjdk_values['CurrentVersion']
+            kjdk_current = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
+                                           jdk_key_path + '\\' + current_version)
+            kjdk_current_values = dict([_winreg.EnumValue(kjdk_current, i)[:2]
+                                        for i in range(_winreg.QueryInfoKey(kjdk_current)[1])])
+            return kjdk_current_values['JavaHome']
+        except exceptions.WindowsError as e:
+            if e.errno == 2:
+                raise RuntimeError(
+                    "Failed to find the Java Development Kit. Please download and install the Oracle JDK 1.6 or later")
+            else:
+                raise
+            
+def find_javac_cmd():
+    """Find the javac executable"""
+    if is_win:
+        jdk_base = find_jdk()
+        javac = os.path.join(jdk_base, "bin", "javac.exe")
+        if os.path.isfile(javac):
+            return javac
+        raise RuntimeError("Failed to find javac.exe in its usual location under the JDK (%s)" % javac)
+    else:
+        # will be along path for other platforms
+        return "javac"
+
+def find_jar_cmd():
+    """Find the javac executable"""
+    if is_win:
+        jdk_base = find_jdk()
+        javac = os.path.join(jdk_base, "bin", "jar.exe")
+        if os.path.isfile(javac):
+            return javac
+        raise RuntimeError("Failed to find jar.exe in its usual location under the JDK (%s)" % javac)
+    else:
+        # will be along path for other platforms
+        return "jar"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 numpy
+Cython>=0.18.0
+

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,6 @@ def ext_modules():
     extra_link_args = None
     if is_win:
         extra_link_args = ['/MANIFEST']
-        extensions += [Extension(name="_get_proper_case_filename",
-                                 sources=["get_proper_case_filename.c"],
-                                 libraries=["shlwapi", "shell32", "ole32"],
-                                 extra_link_args=extra_link_args)]
     try:
         java_home = find_javahome()
         jdk_home = find_jdk()
@@ -108,12 +104,13 @@ def package_path(relpath):
 
 def build_jar_from_single_source(jar, source):
     if needs_compilation(jar, source):
-        javac_command = ['javac', package_path(source)]
+        javac_loc = find_javac_cmd()
+        javac_command = [javac_loc, package_path(source)]
         print ' '.join(javac_command)
         subprocess.check_call(javac_command)
         if not os.path.exists(os.path.dirname(jar)):
             os.mkdir(os.path.dirname(jar))
-        jar_command = ['jar', 'cf', package_path(jar)]
+        jar_command = [find_jar_cmd(), 'cf', package_path(jar)]
         for klass in glob.glob(source[:source.rindex('.')] + '*.class'):
             jar_command.extend(['-C', package_path('java'), klass[klass.index('/') + 1:]])
         print ' '.join(jar_command)

--- a/strtoull.c
+++ b/strtoull.c
@@ -1,0 +1,37 @@
+/* strtoull.c - replacement for strtoull.c function missing from msvcrt */
+#include <ctype.h>
+
+extern unsigned long long int strtoull(const char *s, char **endptr, int base)
+{
+  unsigned long long int value = 0;
+  
+  while (isspace(*s)){
+    s++;
+  }
+
+  if (((base == 0) || (base == 16)) && (s[0] == '0') &&
+      (s[1] == 'x' || s[1] == 'X')) {
+    s += 2;
+    base = 16;
+  } else if (((base == 0) || (base == 8)) && (s[0] == '0')) {
+    base = 8;
+  }
+  while (1) {
+    unsigned long long int digit = 0;
+    if (isdigit(*s)) {
+      digit = *s - '0';
+    } else if ((base > 10) && isxdigit(*s)) {
+      digit = *s + 10 - 'A';
+    } else {
+      break;
+    }
+    if (digit >= base) break;
+    value += digit;
+    s++;
+  }
+
+  if (endptr) {
+    *endptr = (char *)s;
+  }
+  return value;
+}


### PR DESCRIPTION
Hi Vebjorn - here's a pull request to get things working on Windows:
strtoull.c was missing
During setup, Windows needed to do some extra work to find javac.exe and jar.exe
The _javabridge binary referenced the JVM library - on Windows, you need to modify the PATH environment variable to point to it before importing _javabridge in jutil.py
