### PR TITLE
Update find_javahome for Python 3 on macOS

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -76,7 +76,7 @@ def find_javahome():
             arch = "x86_64"
         try:
             result = subprocess.check_output(["/usr/libexec/java_home", "--arch", arch])
-            path = result.strip()
+            path = result.strip().decode("utf-8")
             for place_to_look in (
                 os.path.join(os.path.dirname(path), "Libraries"),
                 os.path.join(path, "jre", "lib", "server")):
@@ -86,7 +86,7 @@ def find_javahome():
                 # can be loaded in the current architecture
                 #
                 if os.path.exists(lib) and \
-                   libc.dlopen_preflight(lib) !=0:
+                   libc.dlopen_preflight(lib.encode("utf-8")) !=0:
                     return path
             else:
                 logger.error("Could not find Java JRE compatible with %s architecture" % arch)


### PR DESCRIPTION
On macOS using Python 3, I was getting the following exception when importing javabrige:

```
$ unset JAVA_HOME && python3 -c 'import javabridge'
Failed to run /usr/libexec/java_home, defaulting to best guess for Java
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/javabridge/locate.py", line 47, in find_javahome
    os.path.join(os.path.dirname(path), "Libraries"),
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/posixpath.py", line 92, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/genericpath.py", line 151, in _check_arg_types
    raise TypeError("Can't mix strings and bytes in path components") from None
TypeError: Can't mix strings and bytes in path components
```

In Python 3, the path returned by the subprocess call to `/usr/libexec/java_home` is a bytes, not an str which `os.path.join` expects. The solution is to decode the path. Special consideration must be made for Python 2, because `libc.dlopen_preflight` expects bytes/str, so the path must be re-encoded.