### PR TITLE
Use PEP-440 compliant version string as an argument to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,6 +309,19 @@ class build_ext(_build_ext):
         self.build_cpython()
 
 
+def pep440_compliant(ver):
+    if ver is None:
+        return ver
+    m = re.match(r"^(?P<version>(\d[\d\.]*))$", ver)
+    if m:
+        return ver
+    m = re.match(r"^(?P<version>(\d[\d\.]*))-(?P<count>\d+)-(?P<sha>.*)$", ver)
+    if m:
+        res = m.group('version') + '.post' + m.group('count') + '+' + m.group('sha')
+        return res
+    return ver
+
+
 def get_version():
     """Get version from git or file system.
 
@@ -345,7 +358,7 @@ def get_version():
         with open(version_file, 'w') as f:
             print('__version__ = "%s"' % git_version, file=f)
 
-    return git_version or cached_version
+    return pep440_compliant(git_version or cached_version)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently direct output of `git describe` was being used as a javabridge's version string fed to setuptools' `setup`.

Due to its non-compliance to [PEP440](https://www.python.org/dev/peps/pep-0440/) an anomaly was observed, where building [python-bioformats](https://github.com/CellProfiler/python-bioformats/) using a conda environment with javabrdige 1.0.14 from [default conda channel](https://anaconda.org/anaconda/javabridge), `setuptools` would not recognize
that the [requirement](https://github.com/CellProfiler/python-bioformats/blob/master/setup.py#L23) "javabridge >=1.0" was already met and start downloading javabridge from PyPI, which causes conda build of `python-bioformats` to fail.

The change makes `version=` argument of `setup` PEP-440 compliant, turning `1.0.14-27-sha` to `1.0.14.post27+sha`.

The string stored in ``javabridge.__version__`` remains intact.