### PR TITLE
 Fix finding JVM and Python 3 libraries in MinGW environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ def ext_modules():
     else:
         javabridge_sources += ['_javabridge_nomac.c']
     if is_win:
+        jdk_lib = os.path.join(jdk_home, "lib")
         if is_mingw:
             #
             # Build libjvm from jvm.dll on Windows.
@@ -120,13 +121,12 @@ def ext_modules():
                    "--kill-at"]
             p = subprocess.Popen(cmd)
             p.communicate()
-            library_dirs = [os.path.abspath(".")]
+            library_dirs = [os.path.abspath("."), jdk_lib]
         else:
             #
             # Use the MSVC lib in the JDK
             #
             extra_link_args = ['/MANIFEST']
-            jdk_lib = os.path.join(jdk_home, "lib")
             library_dirs = [jdk_lib]
             javabridge_sources.append("strtoull.c")
 
@@ -246,7 +246,7 @@ class build_ext(_build_ext):
                                         debug=self.debug)
         needs_manifest = sys.platform == 'win32' and sys.version_info.major == 2 and not is_mingw
         extra_postargs = ["/MANIFEST"] if needs_manifest else None
-        libraries = ["python2.7"] if is_mingw else None
+        libraries = ["python{}".format(sys.version_info[0])] if is_mingw else None
         self.compiler.link(
             CCompiler.SHARED_OBJECT,
             objects, lib_name,

--- a/setup.py
+++ b/setup.py
@@ -244,9 +244,10 @@ class build_ext(_build_ext):
                                         output_dir=self.build_temp,
                                         include_dirs=include_dirs,
                                         debug=self.debug)
-        needs_manifest = sys.platform == 'win32' and sys.version_info.major == 2 and not is_mingw
+        ver = sys.version_info
+        needs_manifest = sys.platform == 'win32' and ver.major == 2 and not is_mingw
         extra_postargs = ["/MANIFEST"] if needs_manifest else None
-        libraries = ["python{}".format(sys.version_info[0])] if is_mingw else None
+        libraries = ["python{}{}".format(ver.major, ver.minor)] if is_mingw else None
         self.compiler.link(
             CCompiler.SHARED_OBJECT,
             objects, lib_name,


### PR DESCRIPTION
I tried pip installing Python-Javabridge in a Conda environment on Cygwin but ran into an error finding ``jvm.lib``. I found that adding the lib location from the path returned by ``find_jdk()`` located this library, so I used it for the MinGW condition in ``ext_modules()``.

Afterward I also ran into a problem with locating ``python2.7.lib`` as described in #125 as I am also using Python 3. I made a small change to use the Python version info to specify the name of the Python library.

Summary of changes:
- Add JDK library directory to library locations when building in MinGW
- Look for Python library number based on version info

Test setup:
- Conda 4.4.10
- Cygwin 2.10.0(0.325/5/3)
- Python 3.6 (also tested on 2.7)
- Pip 9.0.1
- Microsoft Visual C++ 2017 14.12.25810
- Windows 10 v.1703 x64