### PR TITLE
provide way to treat class as java.lang.Class object

### DIFF
--- a/_javabridge.pyx
+++ b/_javabridge.pyx
@@ -500,6 +500,11 @@ cdef class JB_Class:
     def __repr__(self):
         return "<Java class at 0x%x>"%<int>(self.c)
 
+    def as_class_object(self):
+        result = JB_Object()
+        result.o = self.c
+        return result
+
 cdef class __JB_MethodID:
     '''A method ID as returned by get_method_id'''
     cdef:

--- a/javabridge/tests/test_javabridge.py
+++ b/javabridge/tests/test_javabridge.py
@@ -460,3 +460,11 @@ class TestJavabridge(unittest.TestCase):
         result = self.env.get_static_double_field(klass, field_id)
         self.assertAlmostEqual(result, 3.141592653589793)
         
+    def test_06_01_class_as_object(self):
+        klass_map = self.env.find_class("java/util/Map")
+        klass_map_obj = klass_map.as_class_object()
+        klass_klass = self.env.find_class("java/lang/Class")
+        method_getname = self.env.get_method_id(
+            klass_klass, "getName", "()Ljava/lang/String;")
+        jstring = self.env.call_method(klass_map_obj, method_getname)
+        self.assertEqual(self.env.get_string_utf(jstring), "java.util.Map")


### PR DESCRIPTION
Because the JB_Class class is not declared as a subclass of JB_Object, calling some reflection-esque methods via the low-level API becomes more difficult.  If you try to call a method of java.lang.Class, the low-level API methods, which expect a JB_Object, error because they are passed a JB_Class instead (even though that ought to be a valid object).

This patch provides an easy way to obtain one from the other, without going through the ClassLoader shenanigans as in `jutil.py:class_for_name`.

Declaring JB_Class as a subclass of JB_Object also works, but it ends up being a bit clunky due to the different naming (.o vs .c).  This seemed like a safer option, more or guaranteed not to break any existing code.

Suggestions/alternatives welcome!