### PR TITLE
generate global references for classes

### DIFF
--- a/_javabridge.pyx
+++ b/_javabridge.pyx
@@ -126,7 +126,7 @@ cdef extern from "jni.h":
         jclass (* FindClass)(JNIEnv *env, char *name) nogil
         jclass (* GetObjectClass)(JNIEnv *env, jobject obj) nogil
         jboolean (* IsInstanceOf)(JNIEnv *env, jobject obj, jclass klass) nogil
-        jclass (* NewGlobalRef)(JNIEnv *env, jobject lobj) nogil
+        jobject (* NewGlobalRef)(JNIEnv *env, jobject lobj) nogil
         void (* DeleteGlobalRef)(JNIEnv *env, jobject gref) nogil
         void (* DeleteLocalRef)(JNIEnv *env, jobject obj) nogil
         #
@@ -795,8 +795,12 @@ cdef class JB_Env:
         if c == NULL:
             print "Failed to get class "+name
             return
+        cref = self.env[0].NewGlobalRef(self.env, c)
+        if cref == NULL:
+            return (None, MemoryError("Failed to make new global reference"))
+        self.env[0].DeleteLocalRef(self.env, c)
         result = JB_Class()
-        result.c = c
+        result.c = cref
         return result
 
     def get_object_class(self, JB_Object o):


### PR DESCRIPTION
This patch fixes a segfault I had with longer-running jobs.  

I obtain all my classes/fields/methods up front and cache them in python wrapper classes.  However, this doc seems to indicate that classes, like other objects, should be converted to global refs once obtained, otherwise they risk being GC'd while Python still has a pointer.

https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.aix.80.doc/diag/understanding/jni_refs.html

Note that this patch does not provide any mechanism for obtained classes to be GC'd after they are no longer required.  I think the current assumption was that they were never GCd, anyway, so I wasn't too worried about it.  If that is desired, I guess the same `__dealloc__` hook as in JB_Object would need to be added to allow for that.  If there's interest in this patch, I am happy to do that.