### PR TITLE
Fix identification of libjvm.so in Java 9+ on Linux

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -228,7 +228,7 @@ def find_jre_bin_jdk_so():
         for jre_home in (java_home, os.path.join(java_home, "jre")):
             jre_bin = os.path.join(jre_home, 'bin')
             jre_libexec = os.path.join(jre_home, 'bin' if is_win else 'lib')
-            arches = ('amd64', 'i386') if is_linux else ('',)
+            arches = ('amd64', 'i386', '') if is_linux else ('',)
             lib_prefix = '' if is_win else 'lib'
             lib_suffix = '.dll' if is_win else ('.dylib' if is_mac else '.so')
             for arch in arches:


### PR DESCRIPTION
The location of `libjvm.so` on Linux/Solaris changed in Java 9 from `lib/arch` to simply `lib` (see [JEP 220](http://openjdk.java.net/jeps/220)), which prevents installation of Javabridge in these configurations as mentioned in #137 . This small fix adds an empty string as an additional `arches` element for Linux when locating the JDK shared library.

Tested on these platforms:

- Ubuntu 18.04.1 via WSL (Windows Subsystem for Linux) with openjdk-11-jdk
- RHEL 7.5 with java-1.8.0-openjdk-devel