### PR TITLE
Match pattern after each newline

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -120,10 +120,15 @@ def find_javahome():
         java_bin = get_out(["bash", "-c", "type -p java"])
         java_dir = get_out(["readlink", "-f", java_bin])
         java_version_string = get_out(["bash", "-c", "java -version"])
-        if re.match('^openjdk', java_version_string) is not None:
+        if re.search('^openjdk', java_version_string, re.MULTILINE) is not None:
             jdk_dir = os.path.join(java_dir, "..", "..", "..")
-        elif re.match('^java', java_version_string) is not None:
+        elif re.search('^java', java_version_string, re.MULTILINE) is not None:
             jdk_dir = os.path.join(java_dir, "..", "..")
+        else:
+            raise RuntimeError(
+                "Failed to determine JDK vendor. "
+                "OpenJDK and Oracle JDK are supported."
+            )
         jdk_dir = os.path.abspath(jdk_dir)
         return jdk_dir
     elif is_win:


### PR DESCRIPTION
Fix #140.

When java options are specified, the output of `java -version` becomes

```
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on                                               
openjdk version "10.0.2" 2018-07-17
OpenJDK Runtime Environment (build 10.0.2+13)
OpenJDK 64-Bit Server VM (build 10.0.2+13, mixed mode)   
```

instead of

```
openjdk version "10.0.2" 2018-07-17
OpenJDK Runtime Environment (build 10.0.2+13)
OpenJDK 64-Bit Server VM (build 10.0.2+13, mixed mode)   
```

This causes a problem identifying the JDK vendor since the current search `re.match()` only looks at the beginning of the entire string. Searching at the beginning of each newline would be a more suitable approach here and can be achieved with [`re.search()` and `re.MULTILINE`](https://docs.python.org/2/library/re.html#search-vs-match).

I can't fully test this because I have many other issues trying to install javabridge. It does get me past the situation described in #140, but I run into more problems later (which seems to be unrelated).