### PR TITLE
Fixes to installation on ubuntu 18.04

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -235,7 +235,7 @@ def find_jre_bin_jdk_so():
     java_home = find_javahome()
     if java_home is not None:
         found_jvm = False
-        for jre_home in (java_home, os.path.join(java_home, "jre")):
+        for jre_home in (java_home, os.path.join(java_home, "jre"), os.path.join(java_home, 'default-java')):
             jre_bin = os.path.join(jre_home, 'bin')
             jre_libexec = os.path.join(jre_home, 'bin' if is_win else 'lib')
             arches = ('amd64', 'i386', '') if is_linux else ('',)

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,10 @@ def get_jvm_include_dirs():
             include_dirs += ["/System/Library/Frameworks/JavaVM.Framework/Headers"]
     elif is_linux:
         include_dirs += [os.path.join(jdk_home,'include'),
-                         os.path.join(jdk_home,'include','linux')]
+                         os.path.join(jdk_home,'include','linux'),
+                         os.path.join(jdk_home,'default-java','include'),
+                         os.path.join(jdk_home,'default-java','include','linux')
+                         ]
 
     return include_dirs
 


### PR DESCRIPTION
This fixes #145 .

The paths of jdk/jre/jni.h have changed on ubuntu-18.04.  