### PR TITLE
import inspect for inspect.currentframe() on line 435

### DIFF
--- a/javabridge/wrappers.py
+++ b/javabridge/wrappers.py
@@ -15,6 +15,12 @@ import sys
 import numpy as np
 import javabridge as J
 
+try:
+    basestring            # Python 2
+except NameError:
+    basestring = (str, )  # Python 3
+
+
 class JWrapper(object):
     '''A class that wraps a Java object
     

--- a/javabridge/wrappers.py
+++ b/javabridge/wrappers.py
@@ -10,8 +10,9 @@ All rights reserved.
 
 '''
 
-import numpy as np
+import inspect
 import sys
+import numpy as np
 import javabridge as J
 
 class JWrapper(object):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/LeeKamentsky/python-javabridge on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./demo/demo_nogui_with_stmt.py:18:20: E999 SyntaxError: invalid syntax
    print javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);', 
                   ^
./demo/demo_uicallback_noqueue.py:183:16: E999 SyntaxError: invalid syntax
    signal.await();
               ^
./javabridge/wrappers.py:434:13: F821 undefined name 'inspect'
    frame = inspect.currentframe(1)
            ^
./javabridge/wrappers.py:503:44: F821 undefined name 'basestring'
        elif csig == 'C' and isinstance(o, basestring) and len(o) != 1:
                                           ^
2     E999 SyntaxError: invalid syntax
2     F821 undefined name 'inspect'
4
```