### PR TITLE
print() is a function in Python 3

### DIFF
--- a/demo/demo_nogui_with_stmt.py
+++ b/demo/demo_nogui_with_stmt.py
@@ -15,5 +15,5 @@ import os
 import javabridge
 
 with javabridge.vm(run_headless=True):
-    print javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);', 
-                                dict(greetee='world'))
+    print(javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);', 
+                                dict(greetee='world')))


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/LeeKamentsky/python-javabridge on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./demo/demo_nogui_with_stmt.py:18:20: E999 SyntaxError: invalid syntax
    print javabridge.run_script('java.lang.String.format("Hello, %s!", greetee);',
                   ^
./demo/demo_uicallback_noqueue.py:183:16: E999 SyntaxError: invalid syntax
    signal.await();
               ^
2     E999 SyntaxError: invalid syntax
2
```