### PR TITLE
Fix DLL imports for Python 3.8

### DIFF
--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -149,6 +149,11 @@ if sys.platform == "win32":
     #
     os.environ["PATH"] = os.environ["PATH"] + os.pathsep + _find_jvm() + \
        os.pathsep + os.path.join(find_javahome(), "bin")
+    try:
+        os.add_dll_directory(_find_jvm())
+        os.add_dll_directory(os.path.join(find_javahome(), "bin"))
+    except AttributeError:
+        logger.debug("DLL directories not added to environment, may cause problems in Python 3.8+")
     
 elif sys.platform == "darwin":
     # Has side-effect of preloading dylibs


### PR DESCRIPTION
(Copying this fix over from the CellProfiler fork)

It turns out that as of Python 3.8 the Windows system variable `PATH` is no longer used to search for dll/pyd files (security concerns). A new command was added to `os` to allow a user to specify additional locations. Using that to point to java seems to get Javabridge working.

This hopefully fixes #177 and fixes #178