### PR TITLE
issue #28 if openjdk >= 1.8, descend only 2 directories

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -121,7 +121,17 @@ def find_javahome():
         java_dir = get_out(["readlink", "-f", java_bin])
         java_version_string = get_out(["bash", "-c", "java -version"])
         if re.search('^openjdk', java_version_string, re.MULTILINE) is not None:
-            jdk_dir = os.path.join(java_dir, "..", "..", "..")
+            pattern = 'openjdk version "([^"]+)"'
+            match = re.search(pattern, java_version_string, re.MULTILINE)
+            if match:
+                version = match.groups()[0]
+                if version < "1.8":
+                    jdk_dir = os.path.join(java_dir, "..", "..", "..")
+                else:
+                    jdk_dir = os.path.join(java_dir, "..", "..")
+            else:
+                raise RuntimeError("Failed to parse version from %s" % 
+                                   java_version_string)
         elif re.search('^java', java_version_string, re.MULTILINE) is not None:
             jdk_dir = os.path.join(java_dir, "..", "..")
         else:


### PR DESCRIPTION
Open JDK versions 8+ on Linux have a directory structure where the "java" executable is nested only 2 deep whereas 7 was nested 3 deep. This change detects both.