### PR TITLE
fix call_static_method for short,int,long,float,double and object

### DIFF
--- a/_javabridge.pyx
+++ b/_javabridge.pyx
@@ -1082,27 +1082,27 @@ cdef class JB_Env:
             result = unichr(cresult)
         elif sig == 'S':
             with nogil:
-                sresult = jnienv[0].CallShortMethodA(jnienv, klass, m_id, values)
+                sresult = jnienv[0].CallStaticShortMethodA(jnienv, klass, m_id, values)
             result = sresult
         elif sig == 'I':
             with nogil:
-                iresult = jnienv[0].CallIntMethodA(jnienv, klass, m_id, values)
+                iresult = jnienv[0].CallStaticIntMethodA(jnienv, klass, m_id, values)
             result = iresult
         elif sig == 'J':
             with nogil:
-                jresult = jnienv[0].CallLongMethodA(jnienv, klass, m_id, values)
+                jresult = jnienv[0].CallStaticLongMethodA(jnienv, klass, m_id, values)
             result = jresult
         elif sig == 'F':
             with nogil:
-                fresult = jnienv[0].CallFloatMethodA(jnienv, klass, m_id, values)
+                fresult = jnienv[0].CallStaticFloatMethodA(jnienv, klass, m_id, values)
             result = fresult
         elif sig == 'D':
             with nogil:
-                dresult = jnienv[0].CallDoubleMethodA(jnienv, klass, m_id, values)
+                dresult = jnienv[0].CallStaticDoubleMethodA(jnienv, klass, m_id, values)
             result = dresult
         elif sig[0] == 'L' or sig[0] == '[':
             with nogil:
-                oresult = jnienv[0].CallObjectMethodA(jnienv, klass, m_id, values)
+                oresult = jnienv[0].CallStaticObjectMethodA(jnienv, klass, m_id, values)
             if oresult == NULL:
                 result = None
             else:
@@ -1110,7 +1110,7 @@ cdef class JB_Env:
                 if e is not None:
                     raise e
         elif sig == 'V':
-            self.env[0].CallVoidMethodA(self.env, c.c, m.id, values)
+            self.env[0].CallStaticVoidMethodA(self.env, c.c, m.id, values)
             result = None
         else:
             free(<void *>values)


### PR DESCRIPTION
These were being called as non-static, which was detected using `-Xcheck:jni` on this call:

```
def init_context_class_loader():
    '''Set the thread's context class loader to the system class loader
    
    When Java starts, as opposed to the JVM, the thread context class loader
    is set to the system class loader. When you start the JVM, the context
    class loader is null. This initializes the context class loader
    for a thread, if null.
    '''
    current_thread = static_call("java/lang/Thread", "currentThread",
                                 "()Ljava/lang/Thread;")
```

giving this error:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (javaCalls.cpp:592), pid=19511, tid=19836
#  guarantee(method->size_of_parameters() == size_of_parameters()) failed: wrong no. of arguments pushed
#
```