### PR TITLE
fix a couple of code paths where exceptions weren't checked for

### DIFF
--- a/_javabridge.pyx
+++ b/_javabridge.pyx
@@ -1008,6 +1008,14 @@ cdef class JB_Env:
             if oresult == NULL:
                 result = None
             else:
+                # call apparently succeeded, however:
+                # make_jb_object will call back into JNI to make global ref, which
+                # triggers JNI warnings that we did not check for exceptions
+                # calling code should be doing this as well - but it doesn't
+                # have the opportunity to do so before the next JNI call in this
+                # path.
+                jnienv[0].ExceptionOccurred(jnienv)
+
                 result, e = make_jb_object(self, oresult)
                 if e is not None:
                     raise e
@@ -1106,6 +1114,14 @@ cdef class JB_Env:
             if oresult == NULL:
                 result = None
             else:
+                # call apparently succeeded, however:
+                # make_jb_object will call back into JNI to make global ref, which
+                # triggers JNI warnings that we did not check for exceptions
+                # calling code should be doing this as well - but it doesn't
+                # have the opportunity to do so before the next JNI call in this
+                # path.
+                jnienv[0].ExceptionOccurred(jnienv)
+
                 result, e = make_jb_object(self, oresult)
                 if e is not None:
                     raise e

--- a/javabridge/jutil.py
+++ b/javabridge/jutil.py
@@ -1246,9 +1246,17 @@ def get_nice_result(result, sig):
         rklass = env.get_object_class(result)
         m = env.get_method_id(rklass, 'getClass', '()Ljava/lang/Class;')
         rclass = env.call_method(result, m)
+        x = env.exception_occurred()
+        if x is not None:
+            raise JavaException(x)
+
         rkklass = env.get_object_class(rclass)
         m = env.get_method_id(rkklass, 'isPrimitive', '()Z')
         is_primitive = env.call_method(rclass, m)
+        x = env.exception_occurred()
+        if x is not None:
+            raise JavaException(x)
+
         if is_primitive:
             rc = get_class_wrapper(rclass, True)
             classname = rc.getCanonicalName()


### PR DESCRIPTION
(at least before the next JNI call, which is what generates a warning)

This was discovered with -Xcheck:jni, leading to warnings like these

```
WARNING in native method: JNI call made without checking exceptions when required to from CallStaticObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallBooleanMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallStaticObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallBooleanMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallStaticObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallObjectMethodA
WARNING in native method: JNI call made without checking exceptions when required to from CallBooleanMethodA
```

I think what is happening in the two `ObjectMethod` cases is that while the application code is checking the exception state, javabridge is making some followup JNI calls before that can happen, leading to the warnings.

I can gather further evidence for that if you feel it's needed.

I was initially hesitant to put this one up, because javabridge performing (and ignoring) the exception check risks silencing the warnings in the case that they are valid - i.e. an incorrectly written application that does not check the exception itself. However, I think one can argue that since it's impossible to fix these warnings by making the application correct, the warnings become not particularly useful and silencing them is the lesser of two evils.

Certainly open to other suggestions on how to silence these, though.