### PR TITLE
Was unable to locate standard Java on macOS.

### DIFF
--- a/javabridge/locate.py
+++ b/javabridge/locate.py
@@ -85,7 +85,8 @@ def find_javahome():
             path = result.strip().decode("utf-8")
             for place_to_look in (
                 os.path.join(os.path.dirname(path), "Libraries"),
-                os.path.join(path, "jre", "lib", "server")):
+                os.path.join(path, "jre", "lib", "server"),
+                os.path.join(path, "lib", "server")):
                 # In "Java for OS X 2015-001" libjvm.dylib is a symlink to libclient.dylib
                 # which is i686 only, whereas libserver.dylib contains both architectures.
                 for file_to_look in ('libjvm.dylib',


### PR DESCRIPTION
Aside: The line `arch = "x86_64"` is confusing because it causes the error message to point in the wrong direction. But it ultimately doesn't matter. `/usr/libexec/java_home` gives me the same result no matter what `--arch` argument is given.