### PR TITLE
Update javabridge build

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,5 +27,5 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        python -m build
+        pip install dist/*.whl

--- a/_javabridge_mac.pyx
+++ b/_javabridge_mac.pyx
@@ -31,11 +31,11 @@ cdef extern from "mac_javabridge_utils.h":
     int MacIsMainThread() nogil
     void MacRunLoopRunInMode(double) nogil
 
-cdef void StopVM(JavaVM *vm):
+cdef void StopVM(JavaVM *vm) noexcept:
      MacStopVM()
 
 #
 # Unused stub in Mac
 #
-cdef int CreateJavaVM(JavaVM **pvm, void **pEnv, void *args):
+cdef int CreateJavaVM(JavaVM **pvm, void **pEnv, void *args) noexcept:
     return -1

--- a/_javabridge_nomac.pyx
+++ b/_javabridge_nomac.pyx
@@ -9,37 +9,37 @@ cdef extern from "jni.h":
     ctypedef JNIInvokeInterface_ *JavaVM
 
     ctypedef struct JNIInvokeInterface_:
-         jint (*DestroyJavaVM)(JavaVM *vm) nogil
-         jint (*AttachCurrentThread)(JavaVM *vm, void **penv, void *args) nogil
-         jint (*DetachCurrentThread)(JavaVM *vm) nogil
-         jint (*GetEnv)(JavaVM *vm, void **penv, jint version) nogil
-         jint (*AttachCurrentThreadAsDaemon)(JavaVM *vm, void *penv, void *args) nogil
-    jint JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *args) nogil
+         jint (*DestroyJavaVM)(JavaVM *vm) noexcept nogil
+         jint (*AttachCurrentThread)(JavaVM *vm, void **penv, void *args) noexcept nogil
+         jint (*DetachCurrentThread)(JavaVM *vm) noexcept nogil
+         jint (*GetEnv)(JavaVM *vm, void **penv, jint version) noexcept nogil
+         jint (*AttachCurrentThreadAsDaemon)(JavaVM *vm, void *penv, void *args) noexcept nogil
+    jint JNI_CreateJavaVM(JavaVM **pvm, void **penv, void *args) noexcept nogil
 
-cdef int MacStartVM(JavaVM **pvm, JavaVMInitArgs *pVMArgs, char *class_name) nogil:
+cdef int MacStartVM(JavaVM **pvm, JavaVMInitArgs *pVMArgs, char *class_name) noexcept nogil:
     return -1
 
-cdef void StopVM(JavaVM *vm) nogil:
+cdef void StopVM(JavaVM *vm) noexcept nogil:
     vm[0].DestroyJavaVM(vm)
 
-cdef void MacRunLoopInit() nogil:
+cdef void MacRunLoopInit() noexcept nogil:
     pass
 
-cdef void MacRunLoopRun() nogil:
+cdef void MacRunLoopRun() noexcept nogil:
     pass
 
-cdef void MacRunLoopStop() nogil:
+cdef void MacRunLoopStop() noexcept nogil:
     pass
 
-cdef void MacRunLoopReset() nogil:
+cdef void MacRunLoopReset() noexcept nogil:
     pass
 
-cdef int MacIsMainThread() nogil:
+cdef int MacIsMainThread() noexcept nogil:
     return 0
 
-cdef void MacRunLoopRunInMode(double timeout) nogil:
+cdef void MacRunLoopRunInMode(double timeout) noexcept nogil:
     pass
 
-cdef int CreateJavaVM(JavaVM **pvm, void **pEnv, void *args) nogil:
+cdef int CreateJavaVM(JavaVM **pvm, void **pEnv, void *args) noexcept nogil:
     return JNI_CreateJavaVM(pvm, pEnv, args)
 


### PR DESCRIPTION
## Updated file python-publish.yml 

Updated python-publish.yml  to avoid invoking setup.py, instead I'm using `python -m build`
**Source:** 
- [Why you shouldn't invoke setup.py directly](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)

## Updated files _javabridge_mac.pyx and _javabridge_nomac.pyx
**_Reason:_** 
After changing the way javabridge is being built and published, Cython could not compile both of these files  _javabridge_mac.pyx and _javabridge_nomac.pyx, due to an error in mismatching definitions. I found some issues related to Cython 3.0.0 having a slight change in externalized C interfaces. 

Due to this, I added noexcept to the definitions that were external and complaining about mismatch in definitions.

**Sources:**
- [Cython 3.0.0 issue](https://github.com/scikit-learn/scikit-learn/issues/25609)
- Another Cython 3.0.0 related [issue](https://github.com/cython/cython/issues/5540)

With these changes I was able to install and import  javabridge in my google colab :)